### PR TITLE
chore: reduce swagger version to fix build issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lodash": "^4.17.21",
     "lucide-react": "^0.471.0",
     "next": "15.2.1",
-    "next-swagger-doc": "^0.4.1",
+    "next-swagger-doc": "0.4.0",
     "next-themes": "^0.4.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change downgrades the `next-swagger-doc` package from version `0.4.1` to version `0.4.0`.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L26-R26): Downgraded the `next-swagger-doc` package from version `0.4.1` to version `0.4.0`.