### PR TITLE
fix: dont delete prisma user on delete call; webhook will take care of it

### DIFF
--- a/.changeset/gold-rules-leave.md
+++ b/.changeset/gold-rules-leave.md
@@ -1,0 +1,5 @@
+---
+'web': patch
+---
+
+no longer delete user directly in db after we delete clerk user; let webhook take care of it

--- a/src/__tests__/api/user/route.test.ts
+++ b/src/__tests__/api/user/route.test.ts
@@ -383,7 +383,7 @@ describe('User API Routes', () => {
       );
     });
 
-    it('should delete user from Clerk and database', async () => {
+    it('should delete user from Clerk', async () => {
       // Create a mock request with authorization header
       const mockRequest = new MockNextRequest('https://example.com/api/user', {
         authorization: 'Bearer token',
@@ -418,7 +418,6 @@ describe('User API Routes', () => {
       vi.mocked(clerkClient).mockResolvedValueOnce(mockClerkClient);
 
       vi.mocked(prisma.user.findUnique).mockResolvedValue(mockDbUser as User);
-      vi.mocked(prisma.user.delete).mockResolvedValue(mockDbUser as User);
 
       await DELETE(mockRequest as unknown as NextRequest);
 
@@ -427,9 +426,7 @@ describe('User API Routes', () => {
         where: { id: 'user_123' },
       });
       expect(mockDeleteUser).toHaveBeenCalledWith('user_123');
-      expect(prisma.user.delete).toHaveBeenCalledWith({
-        where: { id: 'user_123' },
-      });
+
       expect(NextResponse.json).toHaveBeenCalledWith(
         {
           message: 'User deleted successfully',

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -154,12 +154,6 @@ export async function DELETE(request: NextRequest) {
       const client = await clerkClient();
       await client.users.deleteUser(userId);
 
-      // delete user from database
-      await prisma.user.delete({
-        where: { id: userId },
-      });
-
-      log.info(`User ${userId} deleted from database and clerk`);
       return NextResponse.json(
         {
           message: 'User deleted successfully',


### PR DESCRIPTION
#### Description:
- fix: dont delete prisma user on delete call; webhook will take care of it

#### Attachment(s):

#### Note(s):